### PR TITLE
Adding multiple arguments support for FB.ui and FB.api

### DIFF
--- a/dev/src/unmin/ngFacebook.js
+++ b/dev/src/unmin/ngFacebook.js
@@ -78,8 +78,11 @@ angular.module('facebook', []).provider('$facebook', function() {
                 }
 
                 function wrapWithArgs(func, deferred, args, errorPredicate) {
+                    var argsArray = Array.prototype.slice.call(args, 0);
+
                     wrap(function(callback) {
-                        func(args, callback);
+                        argsArray.push(callback);
+                        func.apply(FB, argsArray);
                     }, deferred, errorPredicate);
                 }
 
@@ -93,25 +96,27 @@ angular.module('facebook', []).provider('$facebook', function() {
                     wrap(func, deferred, errorPredicate);
                 }
 
-                function api(args) {
+                function api() {
                     var deferred = $q.defer();
+                    var apiArguments = arguments;
                     if(initialised) {
-                        wrapWithArgs(FB.api, deferred, args);
+                        wrapWithArgs(FB.api, deferred, apiArguments );
                     } else {
                         queue.push(function() {
-                            wrapWithArgs(FB.api, deferred, args);
+                            wrapWithArgs(FB.api, deferred, apiArguments );
                         });
                     }
                     return deferred.promise;
                 }
 
-                function ui(args) {
+                function ui() {
                     var deferred = $q.defer();
+                    var uiArguments = arguments;
                     if(initialised) {
-                        wrapWithArgs(FB.ui, deferred, args);
+                        wrapWithArgs(FB.ui, deferred, uiArguments);
                     } else {
                         queue.push(function() {
-                            wrapWithArgs(FB.ui, deferred, args);
+                            wrapWithArgs(FB.ui, deferred, uiArguments);
                         });
                     }
                     return deferred.promise;

--- a/dev/test/js/jasmine/ngFacebook.js
+++ b/dev/test/js/jasmine/ngFacebook.js
@@ -109,9 +109,10 @@ describe('facebook', function() {
 
                 it('should call FB.api with args', function() {
                     spyOn(FB, 'api');
-                    facebook.api('/me');
+                    facebook.api('/me', 'post');
                     window.fbAsyncInit();
                     expect(FB.api.mostRecentCall.args[0]).toBe('/me');
+                    expect(FB.api.mostRecentCall.args[1]).toBe('post');
                 });
 
                 it('should reject errors', function() {
@@ -163,9 +164,10 @@ describe('facebook', function() {
 
                 it('should call FB.ui with args', function() {
                     spyOn(FB, 'ui');
-                    facebook.ui('args');
+                    facebook.ui('args1', 'args2');
                     window.fbAsyncInit();
-                    expect(FB.ui.mostRecentCall.args[0]).toBe('args');
+                    expect(FB.ui.mostRecentCall.args[0]).toBe('args1');
+                    expect(FB.ui.mostRecentCall.args[1]).toBe('args2');
                 });
 
                 it('should reject errors', function() {


### PR DESCRIPTION
I've added support for multiple parameters for FB.ui and FB.api

According to documentation:
https://developers.facebook.com/docs/reference/javascript/FB.api/
https://developers.facebook.com/docs/unity/reference/3/FB.UI/

both FB.api and FB.ui take more than one parameter, but last one is always callback. So I proxy all parameters specified by user of $facebook object and add callback as last one.

All unit tests are passing. I slightly modified two of those to assure that we are not checking only first param scenario.
