### PR TITLE
Updated version in Bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "ngFacebook",
-    "version": "0.0.3",
+    "version": "0.0.5",
     "description": "Facebook SDK wrapper for AngularJS Apps",
     "homepage": "https://github.com/ninjatronic/ngFacebook",
     "authors": [


### PR DESCRIPTION
Hey, i noticed that bower.json still had wrong version number   `0.0.3` .
