### PR TITLE
adding support to FB.Canvas.setSize() and FB.Canvas.setAutoGrow()

### DIFF
--- a/dev/src/unmin/ngFacebook.js
+++ b/dev/src/unmin/ngFacebook.js
@@ -186,6 +186,29 @@ angular.module('facebook', []).provider('$facebook', function() {
                     }
                 }
 
+                function canvasSetSize(sizeObject){
+
+                    function setSize(sizeObject){
+                        if(sizeObject && sizeObject.width && sizeObject.height){
+                            FB.Canvas.setSize({width: sizeObject.width, height: sizeObject.height});
+                        } else {
+                            FB.Canvas.setSize();
+                        }
+                    }
+
+                    if(initialised) {
+                        setSize(sizeObject);
+                    } else {
+                        queue.push(function() {
+                            setSize(sizeObject);
+                        })
+                    }
+                }
+
+                function canvasSetAutoGrow(){
+                    FB.Canvas.setAutoGrow();
+                }
+
                 if(initialised) {
                     subscribe();
                 } else {
@@ -199,7 +222,9 @@ angular.module('facebook', []).provider('$facebook', function() {
                     login: login,
                     api: api,
                     ui: ui,
-                    parse: parse
+                    parse: parse,
+                    canvasSetSize: canvasSetSize,
+                    canvasSetAutoGrow: canvasSetAutoGrow
                 };
             }]
     }


### PR DESCRIPTION
Hello,

I just had to add `FB.Canvas.setSize()` and `FB.Canvas.setAutoGrow()` to ngFacebook in a project I am currently developing and would like to share this improvement. :)
Currently no Jasmine tests, sorry. :/ But as you can see it's very simple.

Cheers,
