### PR TITLE
Allow parameter passing to .parse. 

### DIFF
--- a/dev/src/unmin/ngFacebook.js
+++ b/dev/src/unmin/ngFacebook.js
@@ -175,16 +175,19 @@ angular.module('facebook', []).provider('$facebook', function() {
                     }
                     return deferred.promise;
                 }
-                
-                function parse() {
-                    if(initialised) {
-                        FB.XFBML.parse()
+
+	            function parse() {
+		            var deferred = $q.defer();
+		            var parseArguments = arguments;
+		            if(initialised) {
+                        wrapWithArgs(FB.XFBML.parse, deferred, parseArguments);
                     } else {
                         queue.push(function() {
-                            FB.XFBML.parse()
-                        })
+                            wrapWithArgs(FB.XFBML.parse, deferred, parseArguments);
+                        });
                     }
-                }
+		            return deferred.promise;
+	            }
 
                 if(initialised) {
                     subscribe();

--- a/dev/test/js/jasmine/ngFacebook.js
+++ b/dev/test/js/jasmine/ngFacebook.js
@@ -381,8 +381,17 @@ describe('facebook', function() {
                     expect(FB.XFBML.parse).toHaveBeenCalled();
                 });
 
-                it('should return undefined', function() {
-                    expect(facebook.parse()).toBeUndefined();
+                it('should always resolve', function() {
+                    spyOn(FB, 'parse').andCallFake(function(callback) {
+                        callback();
+                    });
+                    var result = {};
+                    facebook.parse().then(function(response) {
+                        result = response;
+                    });
+                    window.fbAsyncInit();
+                    rootScope.$apply();
+                    expect(result).toBeUndefined();
                 });
             });
         });
@@ -646,8 +655,16 @@ describe('facebook', function() {
                     expect(FB.XFBML.parse).toHaveBeenCalled();
                 });
 
-                it('should return undefined', function() {
-                    expect(facebook.parse()).toBeUndefined();
+                it('should always resolve', function() {
+                    spyOn(FB, 'parse').andCallFake(function(callback) {
+                        callback();
+                    });
+                    var result = {};
+                    facebook.parse().then(function(response) {
+                        result = response;
+                    });
+                    rootScope.$apply();
+                    expect(result).toBeUndefined();
                 });
             });
         });


### PR DESCRIPTION
Returns a promise like the other access functions on this module.

We've got several directives calling parse on their own elements, and $facebook was doing a global parse each time - that was causing delays and flashing of FB components (like comments). Having $facebook.parse pass parameters along cleared up that issue.
